### PR TITLE
Handle online events with URL rather than address

### DIFF
--- a/event.coffee
+++ b/event.coffee
@@ -88,6 +88,7 @@ class Event extends Model
     "<!date^#{@starts_at_stamp}^{date_pretty} at {time}|#{@starts_at}>"
 
   @getter 'slack_where', ->
+    return "<#{@location}>" if URL_REGEX.test(@location)
     "<#{@map_url}|#{@venue}>" if @map_url
 
   @getter 'slack_description', ->

--- a/event.coffee
+++ b/event.coffee
@@ -88,8 +88,14 @@ class Event extends Model
     "<!date^#{@starts_at_stamp}^{date_pretty} at {time}|#{@starts_at}>"
 
   @getter 'slack_where', ->
-    return "<#{@location}>" if URL_REGEX.test(@location)
-    "<#{@map_url}|#{@venue}>" if @map_url
+    # does it look like a URL?
+    return "<#{@location}>" if URL_REGEX.test @location
+
+    # does it look like an address? (is there a number?)
+    return "<#{@map_url}|#{@venue}>" if /\d/.test @location
+
+    # I'm out of ideas, just print the text
+    @location
 
   @getter 'slack_description', ->
     compact([@slack_what, @slack_when, @slack_where]).join "\n\n"

--- a/event.test.coffee
+++ b/event.test.coffee
@@ -1,4 +1,8 @@
-{ event_with_url, event_with_address } = require "./fixtures"
+{
+  event_with_url
+  event_with_address
+  event_with_unclear_location
+} = require "./fixtures"
 Event = require "./event"
 assert = require "assert"
 
@@ -14,9 +18,16 @@ test_in_person_event = ->
   expected = "<https://www.google.com/maps/search/?api=1&query=1+Blue+Jays+Way|1 Blue Jays Way>"
   assert.strictEqual actual, expected
 
+test_unclear_event = ->
+  test_event = new Event event_with_unclear_location
+  actual = test_event.slack_where
+  expected = "Online Event"
+  assert.strictEqual actual, expected
+
 try
   test_online_event()
   test_in_person_event()
+  test_unclear_event()
 catch e
   console.error e
   process.exit 1

--- a/event.test.coffee
+++ b/event.test.coffee
@@ -1,0 +1,22 @@
+{ event_with_url, event_with_address } = require "./fixtures"
+Event = require "./event"
+assert = require "assert"
+
+test_online_event = ->
+  test_event = new Event event_with_url
+  actual = test_event.slack_where
+  expected = "<https://google.com>"
+  assert.strictEqual actual, expected
+
+test_in_person_event = ->
+  test_event = new Event event_with_address
+  actual = test_event.slack_where
+  expected = "<https://www.google.com/maps/search/?api=1&query=1+Bluejays+Way|1 Bluejays Way>"
+  assert.strictEqual actual, expected
+
+try
+  test_online_event()
+  test_in_person_event()
+catch e
+  console.error e
+  process.exit 1

--- a/event.test.coffee
+++ b/event.test.coffee
@@ -11,7 +11,7 @@ test_online_event = ->
 test_in_person_event = ->
   test_event = new Event event_with_address
   actual = test_event.slack_where
-  expected = "<https://www.google.com/maps/search/?api=1&query=1+Bluejays+Way|1 Bluejays Way>"
+  expected = "<https://www.google.com/maps/search/?api=1&query=1+Blue+Jays+Way|1 Blue Jays Way>"
   assert.strictEqual actual, expected
 
 try

--- a/fixtures.coffee
+++ b/fixtures.coffee
@@ -1,0 +1,25 @@
+base_event =
+  kind: "calendar#event"
+  etag: "\"3350678618282000\""
+  id: "_clr6arjkbti66t3qc9q7ipj3cph7goi0dlimat3le0n66rrd"
+  status: "confirmed"
+  htmlLink: "https://www.google.com/calendar/event?eid=X2NscjZhcmprYnRpNjZ0M3FjOXE3aXBqM2NwaDdnb2kwZGxpbWF0M2xlMG42NnJyZCBrNmw4b2l1NDE2ZnRjanBqZXRuMHI3YTc5bWU4cHE0ckBp"
+  created: "2023-02-02T12:01:48.000Z"
+  updated: "2023-02-02T12:01:49.141Z"
+  summary: "JS Code Club: Online - Group Programming"
+  description: "Toronto JavaScript\nSaturday, March 18 at 4:00 PM\n\nWelcome to the TorontoJS Group Programming! TorontoJS Group Programming is a friendly coding environment where we can bounce ideas & ask questions fre...\n\nhttps://www.meetup.com/torontojs/events/291350726/"
+
+event_with_url = {
+  base_event...
+  location: "https://google.com"
+}
+
+event_with_address = {
+  base_event...
+  location: "1 Blue Jays Way"
+}
+
+module.exports = {
+  event_with_url
+  event_with_address
+}

--- a/fixtures.coffee
+++ b/fixtures.coffee
@@ -19,7 +19,13 @@ event_with_address = {
   location: "1 Blue Jays Way"
 }
 
+event_with_unclear_location = {
+  base_event...
+  location: "Online Event"
+}
+
 module.exports = {
   event_with_url
   event_with_address
+  event_with_unclear_location
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
   "scripts": {
     "start": "npx coffee index.coffee",
     "dev": "npx nodemon index.coffee",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "npx coffee test.coffee"
+  },
+  "engines": {
+    "node": ">=16"
   },
   "author": "",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "npx coffee index.coffee",
     "dev": "npx nodemon index.coffee",
-    "test": "npx coffee test.coffee"
+    "test": "npx coffee event.test.coffee"
   },
   "engines": {
     "node": ">=16"


### PR DESCRIPTION
#### Changes
- If `@location` is a URL, do not format it like a venue.
- Add test cases for `Event.slack_where` method.
- Add `engines` property to `package.json`.