### PR TITLE
Fix the broken event URL in Slack messages

### DIFF
--- a/event.coffee
+++ b/event.coffee
@@ -11,7 +11,7 @@ axios = require 'axios'
   compact
 } = require 'underscore'
 
-URL_REGEX = /\b(https?:\/\/\S+)\b/
+URL_REGEX = /(https?:\/\/[0-9a-zA-Z\+\&\?\:\=\.\/\-]+)/
 GCAL_KEY = 'AIzaSyA-xW0xIfYvro-zD0JCLRfJwqs6s2MmKmU'
 GCAL_IDS = [
   'tgh4uc5t6uhr4icjrcgqfhe18r2uu3fg@import.calendar.google.com'         # angular

--- a/event.test.coffee
+++ b/event.test.coffee
@@ -2,6 +2,8 @@
   event_with_url
   event_with_address
   event_with_unclear_location
+  event_with_a_tag_description
+  event_with_url_in_description
 } = require "./fixtures"
 Event = require "./event"
 assert = require "assert"
@@ -24,10 +26,24 @@ test_unclear_event = ->
   expected = "Online Event"
   assert.strictEqual actual, expected
 
+test_event_atag = ->
+  test_event = new Event event_with_a_tag_description
+  actual = test_event.url
+  expected = "https://www.meetup.com/meetup-group-iqklclbh/events/296278058/"
+  assert.strictEqual actual, expected
+
+test_event_url = ->
+  test_event = new Event event_with_url_in_description
+  actual = test_event.url
+  expected = "http://www.meetup.com/ruby-lightning-to/events/226535947/"
+  assert.strictEqual actual, expected
+
 try
   test_online_event()
   test_in_person_event()
   test_unclear_event()
+  test_event_url()
+  test_event_atag()
 catch e
   console.error e
   process.exit 1

--- a/fixtures.coffee
+++ b/fixtures.coffee
@@ -24,8 +24,20 @@ event_with_unclear_location = {
   location: "Online Event"
 }
 
+event_with_a_tag_description = {
+  base_event...
+  description: '<a href="https://www.meetup.com/meetup-group-iqklclbh/events/296278058/">https://www.meetup.com/meetup-group-iqklclbh/events/296278058/</a>'
+}
+
+event_with_url_in_description = {
+  base_event...
+  description: 'For full details, including the address, and to RSVP see:\nhttp://www.meetup.com/ruby-lightning-to/events/226535947/\nRuby Lightning Talks T.O.\nCome join us for four lightning-style talks covering intermediate Ruby and Web topics, all in one night!\nFormat:\n6:30-7:00 - Pizza, pop, an...'
+}
+
 module.exports = {
   event_with_url
   event_with_address
   event_with_unclear_location
+  event_with_a_tag_description
+  event_with_url_in_description
 }

--- a/index.coffee
+++ b/index.coffee
@@ -53,7 +53,7 @@ router.get  '/today', today = (ctx)->
   ctx.body = slack_payload events, 'Events today'
 
 router.post '/today', (ctx)->
-  await post_to_slack await Event.today ctx
+  await post_to_slack await today ctx
 
 #
 # Server init

--- a/index.coffee
+++ b/index.coffee
@@ -10,10 +10,7 @@ json    = require 'koa-json'
 cors    = require '@koa/cors'
 Sentry  = require '@sentry/node'
 
-{
-  this_week
-  today
-} = require './event'
+Event = require './event'
 
 {
   slack_payload
@@ -43,7 +40,7 @@ router.get '/', (ctx)->
   """
 
 router.get  '/week', week = (ctx)->
-  events = await this_week()
+  events = await Event.this_week()
   ctx.assert events.length, 404, 'No events this week'
   ctx.body = slack_payload events, 'Events this week'
 
@@ -51,12 +48,12 @@ router.post '/week', (ctx)->
   await post_to_slack await week ctx
 
 router.get  '/today', today = (ctx)->
-  events = await today()
+  events = await Event.today()
   ctx.assert events.length, 404, 'No events today'
   ctx.body = slack_payload events, 'Events today'
 
 router.post '/today', (ctx)->
-  await post_to_slack await today ctx
+  await post_to_slack await Event.today ctx
 
 #
 # Server init


### PR DESCRIPTION
#### Changes
- Fix import in the `index.coffee` file because there's a name collision for `today` functions (one local, one imported).
- Fix the `URL_REGEX` to handle <a> tag descriptions better. Added test cases.